### PR TITLE
Add Domain cross-resource reference to PackageGroup

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2026-08-04T17:36:10Z"
+  build_date: "2026-08-09T02:35:40Z"
   build_hash: db232581a560896c2dc461a244f96d5bf3191ec6
-  go_version: go1.26.5
+  go_version: go1.26.0
   version: v0.62.0
-api_directory_checksum: bcd0bd83574f3f951b1300b0378a22b71f2db5b2
+api_directory_checksum: 2c1213bd27f08307742da2c708af293a1360e306
 api_version: v1alpha1
 aws_sdk_go_version: v1.32.6
 generator_config_info:
-  file_checksum: 8b9c3a864fb478a022092c84bd2ce2643310bcd1
+  file_checksum: 8f7f5f2d37ce3318ee568f6ed2cc074c070c11e2
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -60,6 +60,10 @@ resources:
           is_ignored: True
       Pattern:
         is_primary_key: true
+      Domain:
+        references:
+          resource: Domain
+          path: Spec.Name
     hooks:
       delta_pre_compare:
         code: compareTags(delta, a, b)

--- a/apis/v1alpha1/package_group.go
+++ b/apis/v1alpha1/package_group.go
@@ -34,13 +34,13 @@ type PackageGroupSpec struct {
 	// The name of the domain in which you want to create a package group.
 	//
 	// Regex Pattern: `^[a-z][a-z0-9\-]{0,48}[a-z0-9]$`
-	// +kubebuilder:validation:Required
-	Domain *string `json:"domain"`
+	Domain *string `json:"domain,omitempty"`
 	// The 12-digit account number of the Amazon Web Services account that owns
 	// the domain. It does not include dashes or spaces.
 	//
 	// Regex Pattern: `^[0-9]{12}$`
-	DomainOwner *string `json:"domainOwner,omitempty"`
+	DomainOwner *string                                  `json:"domainOwner,omitempty"`
+	DomainRef   *ackv1alpha1.AWSResourceReferenceWrapper `json:"domainRef,omitempty"`
 	// The pattern of the package group to create. The pattern is also the identifier
 	// of the package group.
 	//

--- a/apis/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/v1alpha1/zz_generated.deepcopy.go
@@ -589,6 +589,11 @@ func (in *PackageGroupSpec) DeepCopyInto(out *PackageGroupSpec) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.DomainRef != nil {
+		in, out := &in.DomainRef, &out.DomainRef
+		*out = new(corev1alpha1.AWSResourceReferenceWrapper)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.Pattern != nil {
 		in, out := &in.Pattern, &out.Pattern
 		*out = new(string)

--- a/config/crd/bases/codeartifact.services.k8s.aws_packagegroups.yaml
+++ b/config/crd/bases/codeartifact.services.k8s.aws_packagegroups.yaml
@@ -64,6 +64,23 @@ spec:
 
                   Regex Pattern: `^[0-9]{12}$`
                 type: string
+              domainRef:
+                description: "AWSResourceReferenceWrapper provides a wrapper around
+                  *AWSResourceReference\ntype to provide more user friendly syntax
+                  for references using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t
+                  \ name: my-api"
+                properties:
+                  from:
+                    description: |-
+                      AWSResourceReference provides all the values necessary to reference another
+                      k8s resource for finding the identifier(Id/ARN/Name)
+                    properties:
+                      name:
+                        type: string
+                      namespace:
+                        type: string
+                    type: object
+                type: object
               pattern:
                 description: |-
                   The pattern of the package group to create. The pattern is also the identifier
@@ -85,7 +102,6 @@ spec:
                   type: object
                 type: array
             required:
-            - domain
             - pattern
             type: object
           status:

--- a/generator.yaml
+++ b/generator.yaml
@@ -60,6 +60,10 @@ resources:
           is_ignored: True
       Pattern:
         is_primary_key: true
+      Domain:
+        references:
+          resource: Domain
+          path: Spec.Name
     hooks:
       delta_pre_compare:
         code: compareTags(delta, a, b)

--- a/helm/crds/codeartifact.services.k8s.aws_packagegroups.yaml
+++ b/helm/crds/codeartifact.services.k8s.aws_packagegroups.yaml
@@ -64,6 +64,23 @@ spec:
 
                   Regex Pattern: `^[0-9]{12}$`
                 type: string
+              domainRef:
+                description: "AWSResourceReferenceWrapper provides a wrapper around
+                  *AWSResourceReference\ntype to provide more user friendly syntax
+                  for references using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t
+                  \ name: my-api"
+                properties:
+                  from:
+                    description: |-
+                      AWSResourceReference provides all the values necessary to reference another
+                      k8s resource for finding the identifier(Id/ARN/Name)
+                    properties:
+                      name:
+                        type: string
+                      namespace:
+                        type: string
+                    type: object
+                type: object
               pattern:
                 description: |-
                   The pattern of the package group to create. The pattern is also the identifier
@@ -85,7 +102,6 @@ spec:
                   type: object
                 type: array
             required:
-            - domain
             - pattern
             type: object
           status:

--- a/pkg/resource/package_group/delta.go
+++ b/pkg/resource/package_group/delta.go
@@ -20,6 +20,7 @@ import (
 
 	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
 	acktags "github.com/aws-controllers-k8s/runtime/pkg/tags"
+	"k8s.io/apimachinery/pkg/api/equality"
 )
 
 // Hack to avoid import errors during build...
@@ -69,6 +70,9 @@ func newResourceDelta(
 		if *a.ko.Spec.DomainOwner != *b.ko.Spec.DomainOwner {
 			delta.Add("Spec.DomainOwner", a.ko.Spec.DomainOwner, b.ko.Spec.DomainOwner)
 		}
+	}
+	if !equality.Semantic.Equalities.DeepEqual(a.ko.Spec.DomainRef, b.ko.Spec.DomainRef) {
+		delta.Add("Spec.DomainRef", a.ko.Spec.DomainRef, b.ko.Spec.DomainRef)
 	}
 	if ackcompare.HasNilDifference(a.ko.Spec.Pattern, b.ko.Spec.Pattern) {
 		delta.Add("Spec.Pattern", a.ko.Spec.Pattern, b.ko.Spec.Pattern)

--- a/pkg/resource/package_group/references.go
+++ b/pkg/resource/package_group/references.go
@@ -17,9 +17,15 @@ package package_group
 
 import (
 	"context"
+	"fmt"
 
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
+	ackerr "github.com/aws-controllers-k8s/runtime/pkg/errors"
+	ackrt "github.com/aws-controllers-k8s/runtime/pkg/runtime"
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 
 	svcapitypes "github.com/aws-controllers-k8s/codeartifact-controller/apis/v1alpha1"
@@ -31,6 +37,10 @@ import (
 // values.
 func (rm *resourceManager) ClearResolvedReferences(res acktypes.AWSResource) acktypes.AWSResource {
 	ko := rm.concreteResource(res).ko.DeepCopy()
+
+	if ko.Spec.DomainRef != nil {
+		ko.Spec.Domain = nil
+	}
 
 	return &resource{ko}
 }
@@ -47,11 +57,119 @@ func (rm *resourceManager) ResolveReferences(
 	apiReader client.Reader,
 	res acktypes.AWSResource,
 ) (acktypes.AWSResource, bool, error) {
-	return res, false, nil
+	ko := rm.concreteResource(res).ko
+
+	resourceHasReferences := false
+	err := validateReferenceFields(ko)
+	if fieldHasReferences, err := rm.resolveReferenceForDomain(ctx, apiReader, ko); err != nil {
+		return &resource{ko}, (resourceHasReferences || fieldHasReferences), err
+	} else {
+		resourceHasReferences = resourceHasReferences || fieldHasReferences
+	}
+
+	return &resource{ko}, resourceHasReferences, err
 }
 
 // validateReferenceFields validates the reference field and corresponding
 // identifier field.
 func validateReferenceFields(ko *svcapitypes.PackageGroup) error {
+
+	if ko.Spec.DomainRef != nil && ko.Spec.Domain != nil {
+		return ackerr.ResourceReferenceAndIDNotSupportedFor("Domain", "DomainRef")
+	}
+	if ko.Spec.DomainRef == nil && ko.Spec.Domain == nil {
+		return ackerr.ResourceReferenceOrIDRequiredFor("Domain", "DomainRef")
+	}
+	return nil
+}
+
+// resolveReferenceForDomain reads the resource referenced
+// from DomainRef field and sets the Domain
+// from referenced resource. Returns a boolean indicating whether a reference
+// contains references, or an error
+func (rm *resourceManager) resolveReferenceForDomain(
+	ctx context.Context,
+	apiReader client.Reader,
+	ko *svcapitypes.PackageGroup,
+) (hasReferences bool, err error) {
+	if ko.Spec.DomainRef != nil && ko.Spec.DomainRef.From != nil {
+		hasReferences = true
+		arr := ko.Spec.DomainRef.From
+		if arr.Name == nil || *arr.Name == "" {
+			return hasReferences, fmt.Errorf("provided resource reference is nil or empty: DomainRef")
+		}
+		namespace, err := ackrt.ResolveCrossNamespaceReference(
+			ctx,
+			rm.cfg.EnableCrossNamespace,
+			&ko.Status.Conditions,
+			ackrt.CrossNamespaceRefKindResource,
+			ko.ObjectMeta.GetNamespace(),
+			arr.Namespace,
+			*arr.Name,
+		)
+		if err != nil {
+			return hasReferences, err
+		}
+		obj := &svcapitypes.Domain{}
+		if err := getReferencedResourceState_Domain(ctx, apiReader, obj, *arr.Name, namespace); err != nil {
+			return hasReferences, err
+		}
+		ko.Spec.Domain = (*string)(obj.Spec.Name)
+	}
+
+	return hasReferences, nil
+}
+
+// getReferencedResourceState_Domain looks up whether a referenced resource
+// exists and is in a ACK.ResourceSynced=True state. If the referenced resource does exist and is
+// in a Synced state, returns nil, otherwise returns `ackerr.ResourceReferenceTerminalFor` or
+// `ResourceReferenceNotSyncedFor` depending on if the resource is in a Terminal state.
+func getReferencedResourceState_Domain(
+	ctx context.Context,
+	apiReader client.Reader,
+	obj *svcapitypes.Domain,
+	name string, // the Kubernetes name of the referenced resource
+	namespace string, // the Kubernetes namespace of the referenced resource
+) error {
+	namespacedName := types.NamespacedName{
+		Namespace: namespace,
+		Name:      name,
+	}
+	err := apiReader.Get(ctx, namespacedName, obj)
+	if err != nil {
+		return err
+	}
+	var refResourceTerminal bool
+	for _, cond := range obj.Status.Conditions {
+		if cond.Type == ackv1alpha1.ConditionTypeTerminal &&
+			cond.Status == corev1.ConditionTrue {
+			return ackerr.ResourceReferenceTerminalFor(
+				"Domain",
+				namespace, name)
+		}
+	}
+	if refResourceTerminal {
+		return ackerr.ResourceReferenceTerminalFor(
+			"Domain",
+			namespace, name)
+	}
+	var refResourceSynced bool
+	for _, cond := range obj.Status.Conditions {
+		if cond.Type == ackv1alpha1.ConditionTypeResourceSynced &&
+			cond.Status == corev1.ConditionTrue {
+			refResourceSynced = true
+		}
+	}
+	if !refResourceSynced {
+		return ackerr.ResourceReferenceNotSyncedFor(
+			"Domain",
+			namespace, name)
+	}
+	if obj.Spec.Name == nil {
+		return ackerr.ResourceReferenceMissingTargetFieldFor(
+			"Domain",
+			namespace, name,
+			"Spec.Name")
+	}
 	return nil
 }


### PR DESCRIPTION
Adds a cross-resource reference to `1` field on `PackageGroup` in `codeartifact-controller`.

`spec.domain` names the CodeArtifact domain the package group is created in. Without a
reference a user has to hardcode a domain name that does not exist until the `Domain`
resource is created, so the two cannot be applied as one unit.

### Fields Added

| # | Field (`generator.yaml` path) | Target | `path` |
| --- | --- | --- | --- |
| 1 | `PackageGroup.Domain` | codeartifact `Domain` (same service) | `Spec.Name` |

`Spec.Name` rather than the ARN: the field holds a bare domain name and
`DescribePackageGroup` echoes it back in that form, so an ARN would produce a delta that
never clears. `service_name` is omitted because `Domain` is managed by this same
controller. No `set: ignore` or `late_initialize` pairing is needed — this is a top-level
field and no Create/Update response writes `Spec.Domain` back.

`domain` left the CRD `required` list as expected, so a manifest supplying only
`domainRef` is accepted by the API server.

### Verification

Deployed this branch to `ack-dev-auto` (`us-west-2`) with a 60s resync period
(`ack-workspace deploy codeartifact --resync-period 60`). PASS requires all four
conditions, held delta-free across at least 3 reconciles.

| # | Resource.field | RefsResolved | Synced | Concrete absent | `*Ref` present | Deltas / 3 resyncs | Result |
| --- | --- | --- | --- | --- | --- | --- | --- |
| 1 | `PackageGroup.domainRef` | ✅ | ✅ | ✅ | ✅ | 0 | **PASS** |

**Summary: 1/1 PASS** — resync period 60s, delta-free across 4 reconciles.

<details>
<summary>Test manifest and observed state</summary>

```yaml
apiVersion: codeartifact.services.k8s.aws/v1alpha1
kind: Domain
metadata:
  name: ref-test-domain
  namespace: ref-test
spec:
  name: ref-test-domain
---
apiVersion: codeartifact.services.k8s.aws/v1alpha1
kind: PackageGroup
metadata:
  name: ref-test-pkggroup
  namespace: ref-test
spec:
  pattern: /npm/ref-test-scope/*
  domainRef:
    from:
      name: ref-test-domain
```

```
$ kubectl -n ref-test get packagegroups.codeartifact.services.k8s.aws ref-test-pkggroup -o json | jq '{conditions, spec}'
{
  "conditions": [
    { "type": "ACK.ReferencesResolved", "status": "True" },
    { "type": "ACK.ResourceSynced", "status": "True" },
    { "type": "Ready", "status": "True" }
  ],
  "spec": {
    "domainRef": { "from": { "name": "ref-test-domain" } },
    "pattern": "/npm/ref-test-scope/*"
  }
}

$ kubectl -n ack-system logs -l app.kubernetes.io/instance=ack-codeartifact-controller \
    --since=4m | grep 'desired resource state has changed' | jq -r '.diff[]?.Path.Parts|join(".")' | sort -u
(no output)
```

Note `spec.domain` is absent and `spec.domainRef` is present, which is what distinguishes a
reference that resolved from one that resolved and was then clobbered by a write-back.

</details>

### Checklist

- [x] Workspace refreshed (runtime, code-generator, controller) before generating
- [x] `service_name` omitted for same-service target
- [x] `path` matches the form the resource's Describe response returns
- [x] Regenerated with `ack-workspace build codeartifact`; controller compiles (`go build ./...`)
- [x] Generated artifacts committed (`apis/`, `pkg/resource/`, `config/crd/`, `helm/`)
- [x] `go.mod` unchanged (same-service, so no new dependency)
- [x] `ATTRIBUTION.md` not regenerated (same-service, no dependency change)
- [x] Verified against the four pass criteria, delta-free across 4 reconciles

/label release/minor
